### PR TITLE
Enhancement/support pug dependencies

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,9 @@
     "dot-notation": "off",
     "max-len": ["warn", 140, 2],
     "no-cond-assign": ["error", "except-parens"],
+    "no-continue": "warn",
     "no-else-return": "warn",
+    "no-plusplus": "warn",
     "no-use-before-define": ["error", { "functions": false, "classes": false }],
     "semi": ["error", "never"],
     "quote-props": ["error", "consistent"]

--- a/README.md
+++ b/README.md
@@ -36,9 +36,37 @@ if(process.env.NODE_ENV === 'development') {
 }
 ````
 
-**Important:** This plugin is designed to be used only with MetalSmith plugins who operate on file basis. Other plugins who depend on `metadata`, etc will not benefit from this or may break.
+3. In case your plugin wraps content which could include other content (dependencies), you can specify custom `RegExp` or `Function`, which should extract those depended files and occashionally rebuild them too.
+
+````js
+// wrap slow plugins with RegEx
+metalsmith.use(incremental(slowPlugin()), /^import ["'](.*)['"]$/mg)
+````
+
+**Important:** Your RegEx has to define one capturing group (which holds the dependency path data), match global and multiline.
+
+````js
+// wrap slow plugins with RegEx
+metalsmith.use(incremental(slowPlugin()), (file, baseDir) => {
+  const dependencies = []
+  // do your custom magic to find dependencies
+  return dependencies
+})
+````
+
+**Note:** You can also pass a hash of `RegEx` or `Function` by file extension.
+
+4. Don't forget to enable file watching (if your are in dev mode)
+````js
+// optionally enable watching
+if(process.env.NODE_ENV === 'development') {
+    incremental.watch(metalsmith)
+}
+````
 
 **Note:** You have to pass your current metalsmith instance to watch.
+
+**Important:** This plugin is designed to be used only with MetalSmith plugins who operate on file basis. Other plugins who depend on `metadata`, etc will not benefit from this or may break.
 
 # Credit/Inspiration
 After we had very long metalsmith builds during development, it was time to seek for change.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "chokidar": "^1.6.1",
-    "debounce": "^1.0.0"
+    "debounce": "^1.0.0",
+    "is-regex": "^1.0.3"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -26,14 +26,8 @@ const metalsmithIncremental = (plugin, baseDir, reDep) => (files, metalsmith, do
     return
   }
 
-  // check dependencies
-  if (baseDir) {
-    if (reDep) {
-      depGraph(files, modifiedFiles, modifiedDirs, baseDir, reDep)
-    } else {
-      depGraph(files, modifiedFiles, modifiedDirs, baseDir)
-    }
-  }
+  // check dependencies first
+  depGraph(files, modifiedFiles, modifiedDirs, baseDir, reDep)
 
   const backupFiles = {}
   let paths = Object.keys(files)
@@ -42,7 +36,6 @@ const metalsmithIncremental = (plugin, baseDir, reDep) => (files, metalsmith, do
   for (let i = 0, l = paths.length; i < l; i++) {
     const path = paths[i]
 
-    // eslint-disable-next-line no-continue
     if (modifiedFiles[path] || isModifiedDir(path, modifiedDirs)) continue
 
     backupFiles[path] = files[path]

--- a/src/lib/dep-graph.js
+++ b/src/lib/dep-graph.js
@@ -1,12 +1,18 @@
 import path from 'path'
+import isRegex from 'is-regex'
 
 import isModifiedDir from './is-modified-dir'
 
 const reDepPug = /include\s+([^\s]+)/mg
 
-const depGraph = (files, modifiedFiles, modifiedDirs, baseDir, reDep = reDepPug) => {
+const depGraph = (files, modifiedFiles, modifiedDirs, baseDir, reDep) => {
   const paths = Object.keys(files)
   const dependencies = {}
+
+  if (!isRegex(reDep)) {
+    // eslint-disable-next-line no-param-reassign
+    reDep = reDepPug
+  }
 
   for (let i = 0, l = paths.length; i < l; i++) {
     const filePath = paths[i]
@@ -26,9 +32,10 @@ const depGraph = (files, modifiedFiles, modifiedDirs, baseDir, reDep = reDepPug)
     while ((match = reDep.exec(file.contents)) !== null) {
       dependency = match[1]
 
-      if (dependencies.charAt(0) === path.sep) {
+      // absolute to optional baseDir
+      if (baseDir && dependencies.charAt(0) === path.sep) {
         dependency = path.join(baseDir, dependency)
-      } else {
+      } else { // relative include/import/require whatever
         dependency = path.join(path.dirname(filePath), dependency)
       }
 

--- a/src/lib/dep-graph.js
+++ b/src/lib/dep-graph.js
@@ -1,24 +1,21 @@
 import path from 'path'
-import isRegex from 'is-regex'
 
 import isModifiedDir from './is-modified-dir'
-
-const reDepPug = /include\s+([^\s]+)/mg
+import getDepRegex from './get-dep-regex'
 
 const depGraph = (files, modifiedFiles, modifiedDirs, baseDir, reDep) => {
   const paths = Object.keys(files)
   const dependencies = {}
 
-  if (!isRegex(reDep)) {
-    // eslint-disable-next-line no-param-reassign
-    reDep = reDepPug
-  }
-
   for (let i = 0, l = paths.length; i < l; i++) {
     const filePath = paths[i]
 
+    // eslint-disable-next-line no-param-reassign
+    reDep = getDepRegex(filePath, reDep)
+
+    // no need to check files without regex
     // no need to check modified files / dirs
-    if (modifiedFiles[filePath] || isModifiedDir(filePath, modifiedDirs)) {
+    if (!reDep || modifiedFiles[filePath] || isModifiedDir(filePath, modifiedDirs)) {
       paths.splice(i, 1)
       l--
       i--

--- a/src/lib/dep-graph.js
+++ b/src/lib/dep-graph.js
@@ -1,5 +1,4 @@
 import path from 'path'
-import isRegex from 'is-regex'
 
 import isModifiedDir from './is-modified-dir'
 import getDepCheck from './get-dep-check'

--- a/src/lib/dep-graph.js
+++ b/src/lib/dep-graph.js
@@ -1,0 +1,49 @@
+import path from 'path'
+
+import isModifiedDir from './is-modified-dir'
+
+const reDepPug = /include\s+([^\s]+)/mg
+
+const depGraph = (files, modifiedFiles, modifiedDirs, baseDir, reDep = reDepPug) => {
+  const paths = Object.keys(files)
+  const dependencies = {}
+
+  for (let i = 0, l = paths.length; i < l; i++) {
+    const filePath = paths[i]
+
+    // no need to check modified files / dirs
+    if (modifiedFiles[filePath] || isModifiedDir(filePath, modifiedDirs)) {
+      paths.splice(i, 1)
+      l--
+      i--
+      continue
+    }
+
+    const file = files[filePath]
+    let match
+    let dependency
+
+    while ((match = reDep.exec(file.contents)) !== null) {
+      dependency = match[1]
+
+      if (dependencies.charAt(0) === path.sep) {
+        dependency = path.join(baseDir, dependency)
+      } else {
+        dependency = path.join(path.dirname(filePath), dependency)
+      }
+
+      if (modifiedFiles[dependency] || isModifiedDir(path, modifiedDirs)) {
+        // yes this is changed by reference
+        // eslint-disable-next-line no-param-reassign
+        modifiedFiles[filePath] = true
+
+        // IMPORTANT: if matched -> reset loop (cause prior items could have included matched item)
+        paths.splice(i, 1)
+        l--
+        i = 0
+      }
+    }
+  }
+}
+
+export default depGraph

--- a/src/lib/get-dep-check.js
+++ b/src/lib/get-dep-check.js
@@ -5,7 +5,7 @@ const reDepHash = {
   pug: /include\s+([^\s]+)/mg,
 }
 
-const getDepRegex = (file, reDep) => {
+const getDepCheck = (file, reDep) => {
   if (!isRegex(reDep)) {
     return reDep
   }
@@ -22,11 +22,11 @@ const getDepRegex = (file, reDep) => {
       key = extension.splice(1)
   }
 
-  if (typeof reDep === 'object' && isRegex(reDep[key])) {
+  if (typeof reDep === 'object' && (typeof reDep[key] === 'function' || isRegex(reDep[key]))) {
     return reDep[key]
   }
 
   return reDepHash[key]
 }
 
-export default getDepRegex
+export default getDepCheck

--- a/src/lib/get-dep-regex.js
+++ b/src/lib/get-dep-regex.js
@@ -1,0 +1,32 @@
+import path from 'path'
+import isRegex from 'is-regex'
+
+const reDepHash = {
+  pug: /include\s+([^\s]+)/mg,
+}
+
+const getDepRegex = (file, reDep) => {
+  if (!isRegex(reDep)) {
+    return reDep
+  }
+
+  const extension = path.extname(file)
+  let key
+
+  switch (extension) {
+    case '.jade':
+      key = 'pug'
+      break
+
+    default:
+      key = extension.splice(1)
+  }
+
+  if (typeof reDep === 'object' && isRegex(reDep[key])) {
+    return reDep[key]
+  }
+
+  return reDepHash[key]
+}
+
+export default getDepRegex

--- a/src/lib/is-modified-dir.js
+++ b/src/lib/is-modified-dir.js
@@ -1,0 +1,11 @@
+const isModifiedDir = (path, modifiedDirs) => {
+  for (let i = 0, l = modifiedDirs.length; i < l; i++) {
+    if (modifiedDirs[i].indexOf(path) === 0) {
+      return true
+    }
+  }
+
+  return false
+}
+
+export default isModifiedDir


### PR DESCRIPTION
fixes #1 

This is a starting point for a generic solution.
In general, we have files with dependencies like CSS's `@import`, JS's `require`, `import`, Pug's `include`, etc. you name it.
So if one of those dependencies has changed, then all it's parents should be considered `modified` too.

As of now this is only done for pug's `include` and allows for supplied custom regex.

Support

- [x] allow for regex
- [x] allow for functions
- [x] custom regex/functions
